### PR TITLE
Make kernel_size and norm in block components configurable

### DIFF
--- a/src/chuchichaestli/models/unet/unet.py
+++ b/src/chuchichaestli/models/unet/unet.py
@@ -39,6 +39,8 @@ from chuchichaestli.models.unet.time_embeddings import (
     SinusoidalTimeEmbedding,
 )
 from chuchichaestli.models.upsampling import Upsample
+from chuchichaestli.models.resnet import Norm
+
 
 BLOCK_MAP = {
     "DownBlock": DownBlock,
@@ -206,7 +208,7 @@ class UNet(nn.Module):
             if i > 0:
                 self.up_blocks.append(Upsample(dimensions, outs))
 
-        self.norm = nn.GroupNorm(groups, outs)
+        self.norm = Norm(dimensions, res_norm_type, outs, groups)
         self.act = ACTIVATION_FUNCTIONS[act]()
         self.conv_out = conv_cls(
             outs, out_channels, kernel_size=out_kernel_size, padding="same"

--- a/src/chuchichaestli/models/unet/unet.py
+++ b/src/chuchichaestli/models/unet/unet.py
@@ -108,7 +108,7 @@ class UNet(nn.Module):
 
         conv_cls = DIM_TO_CONV_MAP[dimensions]
 
-        if n_channels % res_groups != 0:
+        if res_norm_type == "group" and n_channels % res_groups != 0:
             warnings.warn(
                 f"Number of channels ({n_channels}) is not divisible by the number of groups ({res_groups}). Setting number of groups to in_channels."
             )

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -197,3 +197,38 @@ def test_out_channels(
     timestep = 0.5
     output = model(sample, timestep)
     assert output.shape == (1, out_channels) + (64,) * dimensions
+
+
+@pytest.mark.parametrize(
+    "in_kernel_size,out_kernel_size,res_kernel_size",
+    [
+        (1, 1, 1),
+        (3, 3, 3),
+        (5, 5, 5),
+        (7, 7, 7),
+        (9, 9, 9),
+        (1, 3, 5),
+        (5, 3, 1),
+        (3, 1, 5),
+        (5, 1, 3),
+        (1, 5, 3),
+    ],
+)
+def test_kernel_sizes(in_kernel_size, out_kernel_size, res_kernel_size):
+    """Test the forward pass of the UNet model with different kernel sizes."""
+    model = UNet(
+        dimensions=2,
+        down_block_types=("DownBlock", "DownBlock"),
+        up_block_types=("UpBlock", "UpBlock"),
+        n_channels=16,
+        block_out_channel_mults=(1, 2),
+        in_kernel_size=in_kernel_size,
+        out_kernel_size=out_kernel_size,
+        res_kernel_size=res_kernel_size,
+        res_groups=16,
+    )
+    input_dims = (1, 1, 64, 64)
+    sample = torch.randn(*input_dims)
+    timestep = 0.5
+    output = model(sample, timestep)
+    assert output.shape == input_dims

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -32,7 +32,9 @@ def test_cuda_memory_stats_visitor():
     res_block = ResidualBlock(3, 64, 32, True, 64)
     visitor.visit(res_block)
     res_block(torch.randn(1, 64, 32, 32, 32), torch.randn(1, 64))
-    assert len(visitor.memory_stats) == 10 + 1  # 10 layers + resnet block itself
+    assert (
+        len(visitor.memory_stats) == 10 + 2 + 1
+    )  # 10 layers + 2 for the Norm internals + resnet block itself
 
 
 def _test_mps_memory_allocation_visitor():
@@ -41,4 +43,4 @@ def _test_mps_memory_allocation_visitor():
     res_block = ResidualBlock(3, 64, 32, True, 64)
     visitor.visit(res_block)
     res_block(torch.randn(1, 64, 32, 32, 32), torch.randn(1, 64))
-    assert len(visitor.memory_stats) == 10 + 1  # 10 layers + resnet block itself
+    assert len(visitor.memory_stats) == 13 + 1  # 10 layers + resnet block itself


### PR DESCRIPTION
Implements the following:

 - kernel_size other than 3 (would probably require auto-padding...)
- norm options: GroupNorm,` BatchNorm, InstanceNorm ...
- Bonus from #19: prints a warning if the channels are not divisible by groups and defaults to min(channels, groups).