### PR TITLE
Gaussian Noise Regularizer for UNet bottleneck

### DIFF
--- a/src/chuchichaestli/models/unet/blocks.py
+++ b/src/chuchichaestli/models/unet/blocks.py
@@ -27,6 +27,46 @@ from chuchichaestli.models.resnet import ResidualBlock
 from chuchichaestli.models.attention import ATTENTION_MAP
 
 
+class GaussianNoiseBlock(nn.Module):
+    """Gaussian noise regularizer."""
+
+    def __init__(
+        self,
+        sigma: float = 0.1,
+        mu: float = 0.0,
+        detached: bool = True,
+        device: torch.device | str | None = None,
+    ):
+        """Constructor.
+
+        Args:
+          sigma: Relative (to the magnitude of the input) standard deviation for noise generation.
+          mu: Mean for the noise generation.
+          detached: If True, the input is detached for the noise generation.
+          device: Compute device where to pass the noise.
+
+        Note: If detached=False, the network sees the noise as a trainable parameter
+          (no reparametrization trick) and introduce a bias to generate vectors closer
+          to the noise level.
+        """
+        super().__init__()
+        self.sigma = sigma
+        self.detached = detached
+        self.noise = torch.tensor(mu)
+        if device is not None:
+            self.noise = self.noise.to(device)
+
+    def forward(
+        self, x: torch.Tensor, *args, noise_at_inference: bool = False
+    ) -> torch.Tensor:
+        """Forward pass using the reparametrization trick."""
+        if (self.training or noise_at_inference) and self.sigma != 0:
+            scale = self.sigma * x.detach() if self.detached else self.sigma * x
+            sampled_noise = self.noise.repeat(*x.size()).normal_() * scale
+            x = x + sampled_noise
+        return x
+
+
 class DownBlock(nn.Module):
     """Down block for UNet."""
 

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -314,3 +314,227 @@ def test_skip_connection_action(
 
     output = model(sample)
     assert output.shape == input_dims
+
+
+@pytest.mark.parametrize(
+    "dimensions,down_block_types,up_block_types,n_channels,block_out_channel_mults,add_noise,noise_sigma",
+    [
+        (1, ("DownBlock", "DownBlock"), ("UpBlock", "UpBlock"), 32, (1, 2), "up", 0.1),
+        (2, ("DownBlock", "DownBlock"), ("UpBlock", "UpBlock"), 32, (1, 2), "up", 0.1),
+        (3, ("DownBlock", "DownBlock"), ("UpBlock", "UpBlock"), 32, (1, 2), "up", 0.1),
+        # Attention test cases in 2D
+        (
+            2,
+            ("AttnDownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+        (
+            2,
+            ("DownBlock", "DownBlock"),
+            ("AttnUpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.2,
+        ),
+        (
+            2,
+            ("DownBlock", "AttnDownBlock"),
+            ("UpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.1,
+        ),
+        (
+            2,
+            ("DownBlock", "DownBlock"),
+            ("UpBlock", "AttnUpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.2,
+        ),
+        (
+            2,
+            ("AttnDownBlock", "DownBlock"),
+            ("UpBlock", "AttnUpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.1,
+        ),
+        (
+            2,
+            ("AttnDownBlock", "DownBlock"),
+            ("UpBlock", "AttnUpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.1,
+        ),
+        # Attention test cases in 3D
+        (
+            3,
+            ("AttnDownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "DownBlock"),
+            ("AttnUpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "AttnDownBlock"),
+            ("UpBlock", "UpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "DownBlock"),
+            ("UpBlock", "AttnUpBlock"),
+            32,
+            (1, 2),
+            "down",
+            0.1,
+        ),
+        (
+            3,
+            ("AttnDownBlock", "DownBlock"),
+            ("UpBlock", "AttnUpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+        (
+            2,
+            ("DownBlock", "DownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock", "UpBlock"),
+            16,
+            (1, 2, 2),
+            "up",
+            0.1,
+        ),
+        (
+            2,
+            ("DownBlock", "DownBlock", "DownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock", "UpBlock", "UpBlock"),
+            16,
+            (1, 2, 2, 4),
+            "up",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "DownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock", "UpBlock"),
+            16,
+            (1, 2, 2),
+            "down",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "DownBlock", "DownBlock", "DownBlock"),
+            ("UpBlock", "UpBlock", "UpBlock", "UpBlock"),
+            16,
+            (1, 2, 2, 4),
+            "down",
+            0.1,
+        ),
+        # AttentionGate test cases
+        (
+            2,
+            ("DownBlock", "DownBlock"),
+            ("AttnGateUpBlock", "AttnGateUpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+        (
+            3,
+            ("DownBlock", "DownBlock"),
+            ("AttnGateUpBlock", "AttnGateUpBlock"),
+            32,
+            (1, 2),
+            "up",
+            0.1,
+        ),
+    ],
+)
+def test_forward_pass_with_noise(
+    dimensions,
+    down_block_types,
+    up_block_types,
+    n_channels,
+    block_out_channel_mults,
+    add_noise,
+    noise_sigma,
+):
+    """Test the forward pass of the UNet model."""
+    model = UNet(
+        dimensions=dimensions,
+        down_block_types=down_block_types,
+        up_block_types=up_block_types,
+        block_out_channel_mults=block_out_channel_mults,
+        n_channels=n_channels,
+        res_groups=4,
+        num_layers_per_block=1,
+        add_noise=add_noise,
+        noise_sigma=noise_sigma,
+    )
+    input_dims = (1, 1) + (64,) * dimensions
+    sample = torch.randn(*input_dims)  # Example input
+    timestep = 0.5  # Example timestep
+    output1 = model(sample, timestep)
+    output2 = model(sample, timestep)
+    assert output1.shape == input_dims  # Check output shape
+    assert not torch.equal(output1, output2)
+
+
+def test_forward_pass_with_noise_at_inference(
+    dimensions=2,
+    down_block_types=("DownBlock", "DownBlock"),
+    up_block_types=("UpBlock", "UpBlock"),
+    n_channels=64,
+    block_out_channel_mults=(2, 2),
+    add_noise="up",
+    noise_sigma=0.1,
+):
+    model = UNet(
+        dimensions=dimensions,
+        down_block_types=down_block_types,
+        up_block_types=up_block_types,
+        block_out_channel_mults=block_out_channel_mults,
+        n_channels=n_channels,
+        res_groups=4,
+        num_layers_per_block=1,
+        add_noise=add_noise,
+        noise_sigma=noise_sigma,
+    )
+    model.eval()
+    input_dims = (1, 1) + (64,) * dimensions
+    sample = torch.randn(*input_dims)  # Example input
+    timestep = 0.5  # Example timestep
+    output1 = model(sample, timestep)
+    output2 = model(sample, timestep)
+    assert output1.shape == input_dims  # Check output shape
+    assert torch.equal(output1, output2)


### PR DESCRIPTION
As described in #29, I added a `GaussianNoiseBlock` to `.models.unet.blocks`.

The `UNet` class has new keyword arguments to control how the noise is applied in the bottleneck:
- `add_noise=None`: no noise
- `add_noise="up"`: noise applied after the `mid_block`
- `add_noise="down"`: noise applied before the `mid_block`
- `noise_sigma`: controls the noise scaled relatively to the input.
- `noise_detached`: just in case somebody wants to learn noise (but not like in diffusion), otherwise don't touch it ;)

`tests/test_unet.py` was extended to check for noise block behavior at training and inference.