### PR TITLE
Workflow fix (direct pushes)

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -138,7 +138,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.head_ref }}
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
         token: ${{ secrets.READ_WRITE_PAT }}
     - name: Install hatch
@@ -148,6 +148,7 @@ jobs:
       run: |
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@chuchichaestli.dev'
+        git checkout $GITHUB_HEAD_REF
         VERSION=`hatch version`
         hatch version dev
         NEW_VERSION=`hatch version`
@@ -156,8 +157,9 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
+        ref: ${{ github.head_ref }}
         github_token: ${{ secrets.READ_WRITE_PAT }}
-        branch: ${{ github.event.pull_request.head.ref }}
+        branch: ${{ github.head_ref }}
     # - name: Create Pull Request
     #   uses: peter-evans/create-pull-request@v7
     #   with:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -153,10 +153,11 @@ jobs:
         NEW_VERSION=`hatch version`
         git add src/chuchichaestli/__about__.py
         git commit -m "Bump version: $VERSION → $NEW_VERSION"
+        git branch
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-    #    github_token: ${{ secrets.READ_WRITE_PAT }}
+        github_token: ${{ secrets.READ_WRITE_PAT }}
         branch: ${{ github.head_ref }}
     # - name: Create Pull Request
     #   uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -22,12 +22,14 @@ jobs:
         python-version: "3.x"
     - name: Install pypa/build
       run: |
-        python3 -m pip install build --user
+        python -m pip install --upgrade pip
+        python -m pip install build --user
+        python -m pip install .
     - name: Build a binary wheel and a source tarball
       run: |
-        python3 -m build
+        python -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -47,7 +49,7 @@ jobs:
 
     steps:
     - name: Download 📦
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -68,33 +70,32 @@ jobs:
 
     steps:
     - name: Download 📦
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign 📦 with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
-        inputs: |-
+        inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: |-
+      run: >-
         gh release create '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
         --notes ""
-        # --repo '${{ github.repository }}'
-        
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
-      run: |-
+      run: >-
         gh release upload '${{ github.ref_name }}' dist/**
-        # --repo '${{ github.repository }}'
+        --repo '${{ github.repository }}'
 
 
   publish-to-testpypi:
@@ -113,7 +114,7 @@ jobs:
 
     steps:
     - name: Download 📦
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -157,8 +157,9 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.READ_WRITE_PAT }}
         branch: ${{ github.head_ref }}
+        force_with_lease: true
+    #     github_token: ${{ secrets.READ_WRITE_PAT }}
     # - name: Create Pull Request
     #   uses: peter-evans/create-pull-request@v7
     #   with:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build --user
-        python -m pip install .
     - name: Build a binary wheel and a source tarball
       run: |
         python -m build
@@ -59,7 +58,7 @@ jobs:
 
   github-release:
     name: |
-      Sign the 🐍 📦 with Sigstore and upload them to GitHub Release
+      Upload GitHub Release signed with Sigstore
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
@@ -158,15 +157,14 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.READ_WRITE_PAT }}
-        branch: version-bump
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
-      with:
-        branch: version-bump
-        title: 'Dev Version Bump'
-        body: 'Automated dev version bump'
-        base: main
-        head: version-bump
+        branch: ${{ github.event.pull_request.head.ref }}
+    # - name: Create Pull Request
+    #   uses: peter-evans/create-pull-request@v7
+    #   with:
+    #     branch: ${{ steps.bump-version.outputs.BRANCH_NAME }}
+    #     title: 'Dev Version Bump'
+    #     body: 'Automated dev version bump'
+    #     base: main
 
 
   version-bump-release:
@@ -211,7 +209,7 @@ jobs:
         github_token: ${{ secrets.READ_WRITE_PAT }}
         branch: version-bump
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7
       with:
         branch: version-bump
         title: 'Release Version Bump'

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -153,9 +153,6 @@ jobs:
         NEW_VERSION=`hatch version`
         git add src/chuchichaestli/__about__.py
         git commit -m "Bump version: $VERSION → $NEW_VERSION"
-    - name: Pull latest changes
-      run: |
-        git pull --rebase origin version-bump
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -139,8 +139,6 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
-    #    persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
-    #    token: ${{ secrets.READ_WRITE_PAT }}
     - name: Install hatch
       run: |
         python3 -m pip install hatch --user
@@ -153,21 +151,11 @@ jobs:
         NEW_VERSION=`hatch version`
         git add src/chuchichaestli/__about__.py
         git commit -m "Bump version: $VERSION → $NEW_VERSION"
-        git branch
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.head_ref }}
         force_with_lease: true
-    #     github_token: ${{ secrets.READ_WRITE_PAT }}
-    # - name: Create Pull Request
-    #   uses: peter-evans/create-pull-request@v7
-    #   with:
-    #     branch: ${{ steps.bump-version.outputs.BRANCH_NAME }}
-    #     title: 'Dev Version Bump'
-    #     body: 'Automated dev version bump'
-    #     base: main
-
 
   version-bump-release:
     name: Release version bump ⬆️
@@ -186,13 +174,15 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.head_ref }}
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
         token: ${{ secrets.READ_WRITE_PAT }}
     - uses: actions/checkout@v4
       if: github.event_name == 'push'
       with:
         fetch-depth: 0
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
+        token: ${{ secrets.READ_WRITE_PAT }}
     - name: Install hatch
       run: |
         python3 -m pip install hatch --user
@@ -209,12 +199,12 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.READ_WRITE_PAT }}
-        branch: version-bump
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
-      with:
-        branch: version-bump
-        title: 'Release Version Bump'
-        body: 'Automated version bump for release'
-        base: main
-        head: version-bump
+        branch: main
+    # - name: Create Pull Request
+    #   uses: peter-evans/create-pull-request@v7
+    #   with:
+    #     branch: version-bump
+    #     title: 'Release Version Bump'
+    #     body: 'Automated version bump for release'
+    #     base: main
+    #     head: version-bump

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -137,18 +137,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
         ref: ${{ github.head_ref }}
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
-        token: ${{ secrets.READ_WRITE_PAT }}
+        fetch-depth: 0
+    #    persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN.
+    #    token: ${{ secrets.READ_WRITE_PAT }}
     - name: Install hatch
       run: |
         python3 -m pip install hatch --user
     - name: Bump version
       run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@chuchichaestli.dev'
-        git checkout $GITHUB_HEAD_REF
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@chuchichaestli.dev"
         VERSION=`hatch version`
         hatch version dev
         NEW_VERSION=`hatch version`
@@ -157,8 +156,7 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        ref: ${{ github.head_ref }}
-        github_token: ${{ secrets.READ_WRITE_PAT }}
+    #    github_token: ${{ secrets.READ_WRITE_PAT }}
         branch: ${{ github.head_ref }}
     # - name: Create Pull Request
     #   uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/src/chuchichaestli/__about__.py
+++ b/src/chuchichaestli/__about__.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.0.dev0"

--- a/src/chuchichaestli/__about__.py
+++ b/src/chuchichaestli/__about__.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0.dev1"


### PR DESCRIPTION
Somehow, I accidentally managed to directly push to main.

I adjusted the workflow's version bumping:
- dev version bumps now push directly to the PR branch (this avoids unnecessary secondary PRs)
- release version bumps now push directly to the main branch (after pushing a tag)

Notes: I reverted the leaked commits in 4a478035aee5db9bfc19a5b455fa3f35d83c1114 