### PR TITLE
Unsupport Python 3.13 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740303746,
+        "narHash": "sha256-XcdiWLEhjJkMxDLKQJ0CCivmYYCvA5MDxu9pMybM5kM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d068ae5c6516b2d04562de50a58c682540de9bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        makeEnvsForPython = dist: dist.withPackages (p: with p; [
+          numpy
+          torch
+          torchmetrics
+          torchvision
+          timm
+          open-clip-torch
+        ]);
+        pyDists = with pkgs; [
+          python312 python311
+        ];
+        pyEnvs = map makeEnvsForPython pyDists;
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell {
+            packages = [
+              uv
+            ] ++ pyDists ++ pyEnvs;
+
+            shellHook = ''
+              export UV_PYTHON_PREFERENCE="only-system";
+            '';      
+          };
+      }
+    );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,14 @@ authors = [
 maintainers = [{ name = "Yann Billeter", email = "bily@zhaw.ch" }]
 description = "Where you find all the state-of-the-art cooking utensils (salt, pepper, gradient descent... the usual)."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "numpy==1.26.4",
+  "numpy>=1.26",
   "torch>=2.2.2",
   "torchmetrics>=1.4.0",
   "torchvision>=0.20.1",
@@ -27,6 +27,9 @@ dependencies = [
   "open_clip_torch==2.19.0",
 ]
 [project.optional-dependencies]
+dev = ["ruff==0.4.1", "pre-commit==3.7.0", "pytest==8.1.1"]
+
+[dependency-groups]
 dev = ["ruff==0.4.1", "pre-commit==3.7.0", "pytest==8.1.1"]
 
 [project.urls]

--- a/src/chuchichaestli/__about__.py
+++ b/src/chuchichaestli/__about__.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.6.dev0"

--- a/tests/test_unet_blocks.py
+++ b/tests/test_unet_blocks.py
@@ -41,6 +41,7 @@ def net_conf():
 def count_res_blocks(blocks):
     return sum(1 for block in blocks if hasattr(block, 'res_block'))
 
+@pytest.mark.filterwarnings("ignore:Number of channels")
 @pytest.mark.parametrize("num_layers_per_block, expected_res_blocks", [(1, 3), (2, 6)])
 def test_res_blocks(net_conf, num_layers_per_block, expected_res_blocks):
     """Test the number of residual blocks in the UNet model."""


### PR DESCRIPTION
At the moment, Python 3.13 is incompatible with c3li due to the dependencies related to the metrics (see comments in #104). So, I'm un-supporting them for now...

- changed `requires-python` in `pyproject.toml`
- added `dependency-groups` for better `uv` support
- added a `flake.nix` for me ;)

We can have another look at 3.13+ support, once we cleaned up the metrics implementations.